### PR TITLE
Fix different dates in DKAN and CKAN

### DIFF
--- a/analysis/package_stats.py
+++ b/analysis/package_stats.py
@@ -61,6 +61,8 @@ class PackageStats(object):
             update_datetime = dateutil.parser.parse(update_date, ignoretz=True)
         except ValueError:
             return 0
+        except TypeError:
+            return 0
         except OverflowError:
             return 0
         else:


### PR DESCRIPTION
## What does this PR do?
Fix the `metadata_updated` parsing which results in the `update_time` ranking. 

### Cause
DKAN and CKAN use different time formats  for metadata. 

now we use the datetime parser which is aware of more formats and we're not too opinionated.

### Fix

use dateutil parser instead of just `datetime.datetime.strptime` with a defined format. 